### PR TITLE
fix bug by ensuring downgraded fast-api is present in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 gradio==3.22.1
+fastapi==0.95.2
 transformers>=4.27.4
 requests
 pillow


### PR DESCRIPTION
This is a temporary fix, that solves the majority of new issues because the current version of fastapi (0.110.0) is broken with the frozen version of Gradio. But it appears there are so many deprecated items in the code that Gradio can't be updated until those are fixed.

I thought it was a quick fix, but really it would need a lot to go through to make it work.
To save anyone time:
the deprecated "_js" kwarg becomes "js"
The deprecated .update method on CheckboxGroup should change to passing arguments directly to a new instance of the class
The .style method is deprecated keyword arguments should be passed directly to the class. In the case of the Gallery class, the "grid" kwarg no longer exists, but the number of columns can be specified with the "columns" kwarg instead.

There is probably more if someone more familiar with the codebase wanted to really dig in and keep the project up to date.