### PR TITLE
 aesthetic-shadow-v2が公開停止したのでv2はミラーを使い､v1と併用できるよう変更

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ transformers>=4.27.4
 requests
 pillow
 numpy
-torch>=1.7
+torch>=2.0.0
 torchvision
 tqdm
 timm>=1.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ torchvision
 tqdm
 timm>=1.0.8
 print-color
+fastapi==0.112.4

--- a/userscripts/taggers/aesthetic_shadow.py
+++ b/userscripts/taggers/aesthetic_shadow.py
@@ -24,7 +24,7 @@ SCORE_N = {
 def get_aesthetic_tag(score: float):
     for k, v in SCORE_N.items():
         if score > v:
-            return k
+            return f"v2_{k}"
 
 class AestheticShadowV2(Tagger):
     def load(self):

--- a/userscripts/taggers/aesthetic_shadow_v1.py
+++ b/userscripts/taggers/aesthetic_shadow_v1.py
@@ -1,6 +1,6 @@
-# This code is using the image classification "aesthetic-shadow-v2" by shadowlilac (https://huggingface.co/shadowlilac/aesthetic-shadow-v2)
-# and "aesthetic-shadow-v2" is licensed under CC-BY-NC 4.0 (https://spdx.org/licenses/CC-BY-NC-4.0)
-# 配布元公開停止に伴い、手持ちのModelミラー(https://huggingface.co/NEXTAltair/cache_aestheic-shadow-v2)したものに移行しました。
+# This code is using the image classification "aesthetic-shadow" by shadowlilac (https://huggingface.co/shadowlilac/aesthetic-shadow)
+# and "aesthetic-shadow" is licensed under CC-BY-NC 4.0 (https://spdx.org/licenses/CC-BY-NC-4.0)
+# v2配布元公開停止に伴い、v1を使用する
 
 from PIL import Image
 from transformers import pipeline
@@ -14,6 +14,7 @@ from scripts.tagger import Tagger
 BATCH_SIZE = 1
 
 # tags used in Animagine-XL
+# TODO: Animation-XLはv2のスコア基準なので値が異なる
 SCORE_N = {
     'very aesthetic': 0.71,
     'aesthetic': 0.45,
@@ -26,9 +27,9 @@ def get_aesthetic_tag(score: float):
         if score > v:
             return k
 
-class AestheticShadowV2(Tagger):
+class AestheticShadow(Tagger):
     def load(self):
-        self.pipe_aesthetic = pipeline("image-classification", "NEXTAltair/cache_aestheic-shadow-v2", device=devices.device, batch_size=BATCH_SIZE)
+        self.pipe_aesthetic = pipeline("image-classification", "shadowlilac/aesthetic-shadow", device=devices.device, batch_size=BATCH_SIZE)
 
     def unload(self):
         if not settings.current.interrogator_keep_in_memory:
@@ -60,4 +61,4 @@ class AestheticShadowV2(Tagger):
             yield self._get_score(out)
 
     def name(self):
-        return "aesthetic shadow v2"
+        return "aesthetic shadow v1"

--- a/userscripts/taggers/aesthetic_shadow_v1.py
+++ b/userscripts/taggers/aesthetic_shadow_v1.py
@@ -25,7 +25,7 @@ SCORE_N = {
 def get_aesthetic_tag(score: float):
     for k, v in SCORE_N.items():
         if score > v:
-            return k
+            return f"v1_{k}"
 
 class AestheticShadow(Tagger):
     def load(self):


### PR DESCRIPTION
# 変更内容 / Changes

## 主な変更点 / Main Changes
- aesthetic-shadow-v1対応
  - aesthetic-shadow-v2が公開停止したため、v2はミラーを使用しv1と併用できるよう変更
  - aesthetic-shadow-v1とv2の両方を使用可能に

## 動作確認済み環境 / Tested Environments
- OS: Windows 11
- Python 3.12.4
- PyTorch 2.5.1 + CUDA 12.4

# English Version

## Main Changes
- aesthetic-shadow-v2 support
  - Due to the discontinuation of aesthetic-shadow-v2, now using mirror for v2 while maintaining compatibility with v1
  - Both aesthetic-shadow-v1 and v2 can now be used

## Technical Details
- aesthetic-shadow-v2 mirror support
  - Implemented alternative mirror due to service discontinuation
  - Improved compatibility for using both v1 and v2

## Tested Environments
- OS: Windows 11
- Python 3.12.4
- PyTorch 2.5.1 + CUDA 12.4